### PR TITLE
Add direct I/O option.

### DIFF
--- a/tiobench.pl
+++ b/tiobench.pl
@@ -63,7 +63,7 @@ my $read_mbytes;   my $read_time;   my $read_utime;   my $read_stime;
 my $rread_mbytes;  my $rread_time;  my $rread_utime;  my $rread_stime;
 my $num_runs;      my $run_number;  my $help;         my $nofrag;
 my $identifier;    my $debug;       my $dump;         my $progress;
-my $timeout;       my $rawdev;      my $flushCaches;
+my $timeout;       my $rawdev;      my $flushCaches;  my $directIO;
 
 # option parsing
 GetOptions("target=s@",\@targets,
@@ -79,7 +79,8 @@ GetOptions("target=s@",\@targets,
            "dump",\$dump,
            "progress",\$progress,
            "threads=i@",\@threads,
-           "flushCaches", \$flushCaches);
+           "flushCaches", \$flushCaches,
+           "directio", \$directIO,);
 
 &usage if $help || $Getopt::Long::error;
 
@@ -183,6 +184,7 @@ foreach $size (@sizes) {
          $run_string .= " -R" if $rawdev;
          $run_string .= " -D $debug" if $debug > 0;
          $run_string .= " -F" if $flushCaches;
+         $run_string .= " -X" if $directIO;
          foreach $run_number (1..$num_runs) {
             print "Running: $run_string\n"
                if $debug >= $LEVEL_INFO;

--- a/tiotest.c
+++ b/tiotest.c
@@ -387,7 +387,7 @@ static void print_help_and_exit()
 
 	print_option("-F", "Flush OS caches before running test (requires root)", 0);
 
-	print_option("-X", "Use direct I/O to bypass buffer cache", 0);
+	print_option("-X", "Use direct I/O to bypass buffer cache (blocksize must be a multiple of logical blocksize of underlying filesystem)", 0);
 
 	print_option("-h", "Print this help and exit", 0);
 

--- a/tiotest.c
+++ b/tiotest.c
@@ -121,6 +121,8 @@ typedef struct {
 	int	     runRead;
 	int	     runRandomRead;
 	int	     flushCaches;
+	int	     openDirect;
+
 
 	/*
 	  Debug level
@@ -385,6 +387,8 @@ static void print_help_and_exit()
 
 	print_option("-F", "Flush OS caches before running test (requires root)", 0);
 
+	print_option("-X", "Use direct I/O to bypass buffer cache", 0);
+
 	print_option("-h", "Print this help and exit", 0);
 
 	exit(1);
@@ -397,7 +401,7 @@ static void parse_args( ArgumentOptions* args, int argc, char *argv[] )
 
 	while (1)
 	{
-		c = getopt( argc, argv, "f:b:d:t:r:D:k:o:hLRTWSOcMF");
+		c = getopt( argc, argv, "f:b:d:t:r:D:k:o:hLRTWSOcMFX");
 
 		if (c == -1)
 			break;
@@ -484,6 +488,10 @@ static void parse_args( ArgumentOptions* args, int argc, char *argv[] )
 
 		case 'F':
 			args->flushCaches = TRUE;
+			break;
+
+		case 'X':
+			args->openDirect = TRUE;
 			break;
 
 		case 'k':
@@ -579,6 +587,10 @@ static void* do_generic_test(file_io_function io_func,
 	// if sync I/O requested, do it at open time
 	if( args.syncWriting )
 		openFlags |= O_SYNC;
+
+	// if direct I/O requested, do it at open time
+	if( args.openDirect )
+		openFlags |= O_DIRECT;
 
 #ifdef USE_LARGEFILES
 	openFlags |= O_LARGEFILE;


### PR DESCRIPTION
Add an option to open data files with the O_DIRECT option, bypassing the operating system's buffer caches.  Some database systems use this technique to ensure that data is not held in buffer caches (where it may be lost if the host machine crashes) when a transaction has supposedly been committed.  As a database administrator involved in testing the performance of enterprise storage systems, I have found it useful to adapt tiobench to allow tests using direct I/O.