### PR TITLE
Open CACHE_CONTROL_FILE WRONLY

### DIFF
--- a/tiotest.c
+++ b/tiotest.c
@@ -526,7 +526,7 @@ static int flush_caches()
 	}
 	else
 	{
-		fd = open(CACHE_CONTROL_FILE, O_RDWR);
+		fd = open(CACHE_CONTROL_FILE, O_WRONLY);
 		if (fd == -1)
 		{
 			fprintf(stderr, "%s: %s\n", strerror(errno),


### PR DESCRIPTION
/proc/sys/vm/drop_caches is write-only on Ubuntu (checked 18.04 and
20.04) and, thus, `tiotest -F` failed to run tests with the following
message and empty data.

  Permission denied: /proc/sys/vm/drop_caches